### PR TITLE
Sharpness: tests and demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,8 +27,9 @@
     <script type="module" src="scripts/resize_image_demo.js"></script>
     <script type="module" src="scripts/change_opacity_demo.js"></script>
     <script type="module" src="scripts/change_shadow_demo.js"></script>
-    <script type="module" src="scripts/change_tint_demo.js"></script>-->
-    <script type="module" src="scripts/change_highlights_demo.js"></script>
+    <script type="module" src="scripts/change_tint_demo.js"></script>
+    <script type="module" src="scripts/change_highlights_demo.js"></script>-->
+    <script type="module" src="scripts/change_sharpness_demo.js"></script>
 
 </body>
 

--- a/demo/scripts/change_sharpness_demo.js
+++ b/demo/scripts/change_sharpness_demo.js
@@ -1,0 +1,19 @@
+import EditPix from "../../src/editpix.js";
+
+const editpix = new EditPix();
+
+const url = "images/img7.jpeg";
+
+var image = new Image();
+image.src = url;
+
+//waiting image load
+image.onload = () => {
+
+    editpix.changeSharpness(image, 70)
+        .then(resultImage => {
+            document.body.appendChild(image);
+            document.body.appendChild(resultImage);
+        })
+        .catch(error => { console.log(error) })
+}

--- a/src/core/change_sharpness.js
+++ b/src/core/change_sharpness.js
@@ -6,7 +6,7 @@ function changeSharpness(pixelArray, width, height, factor) {
         [0, -1, 0]
     ];
 
-    const tempPixelArray = pixelArray.slice(); // ...pixelArray;
+    const tempPixelArray = [...pixelArray];
 
     for (let y = 1; y < height - 1; y++) {
         for (let x = 1; x < width - 1; x++) {
@@ -21,17 +21,13 @@ function changeSharpness(pixelArray, width, height, factor) {
                 }
             }
             const index = (y * width + x) * 4;
-            pixelArray[index] = clamp(tempPixelArray[index] + factor * sumR);
-            pixelArray[index + 1] = clamp(tempPixelArray[index + 1] + factor * sumG);
-            pixelArray[index + 2] = clamp(tempPixelArray[index + 2] + factor * sumB);
+            pixelArray[index] = tempPixelArray[index] + factor * sumR;
+            pixelArray[index + 1] = tempPixelArray[index + 1] + factor * sumG;
+            pixelArray[index + 2] = tempPixelArray[index + 2] + factor * sumB;
         }
     }
 
     return pixelArray;
-}
-
-function clamp(value) {
-    return Math.max(0, Math.min(255, value));
 }
 
 export default changeSharpness;

--- a/src/editpix.js
+++ b/src/editpix.js
@@ -16,6 +16,7 @@ import changeShadows from "./core/change_shadows.js";
 import changeExposure from "./core/change_exposure.js";
 import changeTint from "./core/change_tint.js"
 import changeHighlights from "./core/change_highlights.js";
+import changeSharpness from "./core/change_highlights.js";
 
 var EditPix = function () { };
 
@@ -185,6 +186,13 @@ EditPix.prototype.changeHighlights = (image, factor) => {
         throw new Error("Invalid shadow factor: must be a value between -100 and 100");
     const pixelArray = imageManager.getPixelArray(image);
     return imageManager.convertToImage(changeHighlights(pixelArray, factor), image.naturalWidth, image.naturalHeight);
+}
+
+EditPix.prototype.changeSharpness = (image, factor) => {
+    if (factor < -100 || factor > 100)
+        throw new Error("Invalid sharpness factor: must be a value between -100 and 100");
+    const pixelArray = imageManager.getPixelArray(image);
+    return imageManager.convertToImage(changeSharpness(pixelArray, factor), image.naturalWidth, image.naturalHeight);
 }
 
 export default EditPix;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -344,3 +344,22 @@ describe('changeHiglights', () => {
         expect(testColor1[2]).toEqual(testColor2[2]);
     });
 });
+
+describe('changeSharpness', () => {
+    test('basic functionality test', () => {
+        const inputArray = [243, 22, 108, 255, 173, 12, 0, 255]; // An array of pixel values representing an image
+        const sharpenedArray = changeSharpness(inputArray, 2, 1, 32);
+    
+        // Verify that the sharpened image is processed correctly
+        expect(sharpenedArray).not.toEquals(inputArray)
+    });
+
+    test('handle negative factor correctly', () => {
+        const inputArray = [243, 22, 108, 255, 173, 12, 0, 255]; // An array of pixel values representing an image
+        const sharpenedArray = changeSharpness(inputArray, 2, 1, -40);
+
+        // Verify that the function correctly handles negative sharpening factor
+        expect(sharpenedArray).not.toEquals(inputArray)
+    });
+
+});

--- a/test/editpix.test.js
+++ b/test/editpix.test.js
@@ -175,3 +175,22 @@ describe('EditPix changeHighlights method', () => {
         }
     });
 });
+
+describe('EditPix changeSharpness method', () => {
+    test('should reject lower out-of-range factors', () => {
+        try {
+            const editPix = new EditPix();
+            editPix.changeSharpness([0, 234, 87], 150);
+        } catch (e) {
+            expect(e).toEqual(new Error("Invalid sharpness factor: must be a value between -100 and 100"));
+        }
+    });
+    test('should reject upper out-of-range factors', () => {
+        try {
+            const editPix = new EditPix(); 
+            editPix.changeSharpness([0, 234, 87], -123);
+        } catch (e) {
+            expect(e).toEqual(new Error("Invalid sharpness factor: must be a value between -100 and 100"));
+        }
+    });
+});


### PR DESCRIPTION
From the demo, we can see that this is more of a definition-type-thing, rather than a proper edge-detecting sharpness.

We might close #30 since `changeSharpness` is basically applying a hybrid definition-sharpness effect (and that would mark the end of #2 too).

Since we have an edge detection algorithm ready, we might use it later for a proper sharpening function, and the current one might be renamed to `changeDefinition`.